### PR TITLE
fix implementation exception on macos "No implementation found for method cleanUpDanglingCalls on channel flutter_web_auth_2"

### DIFF
--- a/flutter_web_auth_2/macos/Classes/FlutterWebAuth2Plugin.swift
+++ b/flutter_web_auth_2/macos/Classes/FlutterWebAuth2Plugin.swift
@@ -44,6 +44,9 @@ public class FlutterWebAuth2Plugin: NSObject, FlutterPlugin {
                 return
             }
             flutterResult = result
+        } else if call.method == "cleanUpDanglingCalls" {
+            // we do not keep track of old callbacks on iOS, so nothing to do here
+            result(nil)
         } else {
             result(FlutterMethodNotImplemented)
         }


### PR DESCRIPTION
fix implementation exception on macos "No implementation found for method cleanUpDanglingCalls on channel flutter_web_auth_2"
